### PR TITLE
feat: v1.1.1 - git log tree, lazy loading, hunk stage/unstage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,21 @@
 	"better-diff-viewer.isAutoRefresh": true,
 	"better-diff-viewer.showBtnIcon": true,
 	"better-diff-viewer.showBtnLongDesc": true,
-	"better-diff-viewer.showBtnShortDesc": false
+	"better-diff-viewer.showBtnShortDesc": false,
+	"workbench.colorCustomizations": {
+		"titleBar.activeBackground": "#3513f8",
+		"tab.activeBorder": "#ff0000",
+		"tab.activeBorderTop": "#ff0000",
+		"tab.activeBackground": "#4c00ff",
+		"tab.unfocusedActiveBackground": "#03000aa2",
+		"activityBar.background": "#540754",
+		"titleBar.inactiveBackground": "#540754",
+		"titleBar.inactiveForeground": "#FFF9FF",
+		"statusBar.background": "#540754",
+		"statusBar.foreground": "#FFF9FF",
+		"statusBar.debuggingBackground": "#540754",
+		"statusBar.debuggingForeground": "#FFF9FF",
+		"statusBar.noFolderBackground": "#540754",
+		"statusBar.noFolderForeground": "#FFF9FF"
+	}
 }

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ For example, view Diff in HTML, revert a file ...
 - [x] Triggering extension commands from bottom toolbar
 - [x] Specify panel location (i.e. in editor or panel)
 - [x] View content of a GIT commit
-- [x] Support hunk action - e.g. revert hunk only code
+- [x] Support hunk action - e.g. revert, stage, or unstage individual hunks
 - [x] Binary file protection - large binary patches are automatically excluded to prevent renderer hangs
 - [x] Configurable max diff lines per file to handle very large diffs
-- [ ] Show and interact with git log tree
+- [x] Filter files in the diff view by name with autocomplete dropdown
+- [x] Smart tab placement — opens in the rightmost split when multiple editor groups exist, otherwise opens beside
+- [x] Git log tree panel -- toggle with the branch icon in the toolbar to browse all-branch commit history and click any commit to view its diff; commits load lazily (20 at a time) as you scroll
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"icon": "images/extension-icon.png",
 	"publisher": "SamWang",
 	"author": "Sam Wang",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"engines": {
 		"vscode": "^1.120.0"
 	},

--- a/resources/css/custom-style.css
+++ b/resources/css/custom-style.css
@@ -50,6 +50,79 @@
 	align-self: stretch;
 }
 
+#file-filter-wrap {
+	position: relative;
+	margin-left: auto;
+	display: flex;
+	align-items: stretch;
+}
+
+#file-filter-input {
+	padding: 2px 6px;
+	width: 200px;
+	box-sizing: border-box;
+}
+
+#file-filter-dropdown {
+	display: none;
+	position: absolute;
+	top: 100%;
+	right: 0;
+	min-width: 100%;
+	max-height: 300px;
+	overflow-y: auto;
+	background: white;
+	border: 1px solid #ccc;
+	border-top: none;
+	box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+	z-index: 1000;
+}
+
+.file-filter-option {
+	padding: 4px 8px;
+	cursor: pointer;
+	white-space: nowrap;
+	font-size: 13px;
+	color: #111;
+}
+
+.file-filter-option:hover {
+	background: #e8f0fe;
+}
+
+.file-filter-option mark {
+	background: #fff3cd;
+	padding: 0;
+}
+
+.bdv-cs-dark #file-filter-input {
+	background-color: #333;
+	color: #fff;
+	border-color: #555;
+}
+
+.bdv-cs-dark #file-filter-input::placeholder {
+	color: #aaa;
+}
+
+.bdv-cs-dark #file-filter-dropdown {
+	background: #2d2d2d;
+	border-color: #555;
+}
+
+.bdv-cs-dark .file-filter-option {
+	color: #eee;
+}
+
+.bdv-cs-dark .file-filter-option:hover {
+	background: #404040;
+}
+
+.bdv-cs-dark .file-filter-option mark {
+	background: #5a4a00;
+	color: #ffd;
+}
+
 
 .custom-git-btn {
 	display: flex;

--- a/resources/css/custom-style.css
+++ b/resources/css/custom-style.css
@@ -1,3 +1,172 @@
+/* Layout */
+#main-container {
+	display: flex;
+	align-items: flex-start;
+}
+
+#git-log-panel {
+	display: none;
+	flex-direction: column;
+	position: sticky;
+	top: 0;
+	height: 100vh;
+	width: 280px;
+	min-width: 200px;
+	flex-shrink: 0;
+	border-right: 1px solid #ccc;
+	overflow: hidden;
+}
+
+#git-log-panel.visible {
+	display: flex;
+}
+
+#git-log-panel-header {
+	display: flex;
+	align-items: center;
+	padding: 4px 8px;
+	border-bottom: 1px solid #ccc;
+	font-weight: bold;
+	font-size: 13px;
+	flex-shrink: 0;
+}
+
+#git-log-panel-header span {
+	flex: 1;
+}
+
+#git-log-panel-header button {
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 2px 4px;
+}
+
+#git-log-list {
+	flex: 1;
+	overflow-y: auto;
+}
+
+#diff-view-area {
+	flex: 1;
+	min-width: 0;
+}
+
+.git-log-commit {
+	padding: 6px 8px;
+	border-bottom: 1px solid #eee;
+	cursor: pointer;
+	font-size: 12px;
+}
+
+.git-log-commit:hover {
+	background: #f0f4ff;
+}
+
+.git-log-commit.active {
+	background: #e3edff;
+	border-left: 3px solid #4a90e2;
+	padding-left: 5px;
+}
+
+.git-log-hash {
+	font-family: monospace;
+	color: #c44;
+	font-size: 11px;
+}
+
+.git-log-subject {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	font-size: 12px;
+	margin-top: 2px;
+}
+
+.git-log-meta {
+	font-size: 11px;
+	color: #888;
+	margin-top: 2px;
+}
+
+.git-log-refs {
+	margin-bottom: 2px;
+}
+
+.git-log-ref {
+	display: inline-block;
+	font-size: 10px;
+	padding: 1px 4px;
+	border-radius: 3px;
+	margin-right: 3px;
+	font-weight: bold;
+}
+
+.git-log-ref-head {
+	background: #7c3aed;
+	color: white;
+}
+
+.git-log-ref-branch {
+	background: #16a34a;
+	color: white;
+}
+
+.git-log-ref-tag {
+	background: #ca8a04;
+	color: white;
+}
+
+.git-log-ref-remote {
+	background: #2563eb;
+	color: white;
+}
+
+.git-log-loading,
+.git-log-empty {
+	padding: 8px;
+	color: #888;
+	font-size: 12px;
+}
+
+/* Dark mode for git log */
+.bdv-cs-dark #git-log-panel {
+	border-right-color: #555;
+}
+
+.bdv-cs-dark #git-log-panel-header {
+	border-bottom-color: #555;
+}
+
+.bdv-cs-dark #git-log-panel-header button {
+	color: #fff;
+}
+
+.bdv-cs-dark #git-log-panel-header button:hover {
+	background: #444;
+}
+
+.bdv-cs-dark .git-log-commit {
+	border-bottom-color: #444;
+}
+
+.bdv-cs-dark .git-log-commit:hover {
+	background: #2a2a3a;
+}
+
+.bdv-cs-dark .git-log-commit.active {
+	background: #1a2a4a;
+	border-left-color: #4a90e2;
+}
+
+.bdv-cs-dark .git-log-hash {
+	color: #f88;
+}
+
+.bdv-cs-dark .git-log-meta {
+	color: #999;
+}
+
 /* Color CSS */
 #diff2html-container {
 	background: white;
@@ -162,9 +331,10 @@
 }
 
 .d2h-info .custom-git-btn {
-	position: absolute;
+	display: inline-flex;
 	height: 16px;
 	line-height: 12px;
 	font-size: 10px;
-	left: 35px;
+	vertical-align: middle;
+	margin-right: 6px;
 }

--- a/resources/js/diff-viewer-ui.js
+++ b/resources/js/diff-viewer-ui.js
@@ -1,7 +1,11 @@
 const vscode = acquireVsCodeApi();
 const diff2htmlContainerId = "#diff2html-container";
+const GIT_LOG_PAGE_SIZE = 20;
 let diff2htmlUi;
 let data = {};
+let gitLogOffset = 0;
+let gitLogHasMore = true;
+let gitLogLoading = false;
 
 window.addEventListener("message", (event) => {
 	const uiMessage = event.data;
@@ -10,6 +14,8 @@ window.addEventListener("message", (event) => {
 			data = uiMessage?.data;
 			showDiff2HtmlUi();
 		}
+	} else if (uiMessage.command === "showGitLog") {
+		renderGitLog(uiMessage.data?.commits ?? [], uiMessage.data?.offset ?? 0, uiMessage.data?.hasMore ?? false);
 	}
 });
 
@@ -69,6 +75,19 @@ function addButtonListeners() {
 		jQuery("#file-filter-input").val(val);
 		applyFileFilter(val);
 		jQuery("#file-filter-dropdown").hide();
+	});
+
+	jQuery("#git-log-toggle-btn").on("click", toggleGitLog);
+	jQuery("#git-log-refresh-btn").on("click", () => loadGitLog(0));
+	jQuery("#git-log-list").on("scroll", function () {
+		if (!gitLogLoading && gitLogHasMore && this.scrollTop + this.clientHeight >= this.scrollHeight - 80) {
+			loadGitLog(gitLogOffset);
+		}
+	});
+	jQuery("#git-log-list").on("click", ".git-log-commit", function () {
+		jQuery(".git-log-commit.active").removeClass("active");
+		jQuery(this).addClass("active");
+		vscode.postMessage({ command: "viewCommitFromLog", hash: jQuery(this).data("hash") });
 	});
 }
 
@@ -230,31 +249,27 @@ function addUiElementsToDiff2HtmlUi(config) {
 		}
 	});
 
-	if (!isStagedView && config?.enableRevertHunk) {
-		jQuery(".d2h-info .d2h-code-line")
-			.filter(function () {
-				return jQuery(this).html() && jQuery(this).html().trim() !== "File without changes";
-			})
-			.each(function () {
-				const jContainer = jQuery(this).closest(".d2h-info");
-				const jFileWrapper = jQuery(this).closest(".d2h-file-wrapper");
-				const relativeFilePath = jFileWrapper.find(".d2h-file-name").html();
-				const hunkHeader = jQuery(this).html().trim();
-				const fileChangeState = getFileChangeState(jFileWrapper);
-				addCustomGitBtn({
-					selector: jContainer,
-					btnClass: "custom-git-danger-btn",
-					action: "revertHunk",
-					title: "Revert Hunk",
-					relativeFilePath: relativeFilePath,
-					fileChangeState: fileChangeState,
-					iconClass: "fa-solid fa-rotate-left",
-					shortDesc: "R",
-					longDesc: "Revert",
-					hunkHeader: hunkHeader,
-				});
-			});
-	}
+	jQuery(".d2h-info .d2h-code-line")
+		.filter(function () {
+			return jQuery(this).html() && jQuery(this).html().trim() !== "File without changes";
+		})
+		.each(function () {
+			const jFileWrapper = jQuery(this).closest(".d2h-file-wrapper");
+			const relativeFilePath = jFileWrapper.find(".d2h-file-name").html();
+			const hunkHeader = jQuery(this).html().trim();
+			const fileChangeState = getFileChangeState(jFileWrapper);
+			const base = { selector: jQuery(this), prepend: true, relativeFilePath, fileChangeState, hunkHeader };
+
+			if (isStagedView) {
+				addCustomGitBtn({ ...base, action: "unstageHunk", title: "Unstage Hunk", iconClass: "fa-solid fa-minus", shortDesc: "R", longDesc: "Remove", isDisabledAfterClicked: true });
+			} else {
+				// Prepend Add first so Revert ends up before it after the second prepend
+				addCustomGitBtn({ ...base, action: "stageHunk", title: "Stage Hunk", iconClass: "fa-solid fa-plus", shortDesc: "A", longDesc: "Add", isDisabledAfterClicked: true });
+				if (config?.enableRevertHunk) {
+					addCustomGitBtn({ ...base, btnClass: "custom-git-danger-btn", action: "revertHunk", title: "Revert Hunk", iconClass: "fa-solid fa-rotate-left", shortDesc: "R", longDesc: "Revert" });
+				}
+			}
+		});
 }
 
 function getFileChangeState(selector) {
@@ -272,16 +287,19 @@ function getFileChangeState(selector) {
 }
 
 function addCustomGitBtn(options) {
-	const { selector, action, title, relativeFilePath, fileChangeState, iconClass, shortDesc, longDesc, btnClass, hunkHeader, isDisabledAfterClicked } = options;
+	const { selector, action, title, relativeFilePath, fileChangeState, iconClass, shortDesc, longDesc, btnClass, hunkHeader, isDisabledAfterClicked, prepend } = options;
 	const hunkHeaderStr = addDataElement("hunk-header", hunkHeader);
 	const isDisabledAfterClickedStr = addDataElement("is-disabled-after-clicked", isDisabledAfterClicked);
 	const actionStr = addDataElement("command", action);
 	const fileChangeStateStr = addDataElement("file-change-state", fileChangeState);
 	const relativeFilePathStr = addDataElement("relative-file-path", relativeFilePath);
 
-	jQuery(selector).append(
-		`<button class="custom-git-btn ${btnClass}" title="${title}" ${actionStr} ${relativeFilePathStr} ${fileChangeStateStr} ${hunkHeaderStr} ${isDisabledAfterClickedStr}><span class="btn-icon"><i class="${iconClass}"></i></span><span class="btn-short-desc">${shortDesc}</span><span class="btn-long-desc">${longDesc}</span></button>`
-	);
+	const html = `<button class="custom-git-btn ${btnClass}" title="${title}" ${actionStr} ${relativeFilePathStr} ${fileChangeStateStr} ${hunkHeaderStr} ${isDisabledAfterClickedStr}><span class="btn-icon"><i class="${iconClass}"></i></span><span class="btn-short-desc">${shortDesc}</span><span class="btn-long-desc">${longDesc}</span></button>`;
+	if (prepend) {
+		jQuery(selector).prepend(html);
+	} else {
+		jQuery(selector).append(html);
+	}
 }
 
 function applyFileFilter(filterText) {
@@ -326,6 +344,85 @@ function showFileFilterDropdown(filterText) {
 	});
 
 	$dropdown.show();
+}
+
+function toggleGitLog() {
+	const $panel = jQuery("#git-log-panel");
+	const isVisible = $panel.hasClass("visible");
+	if (isVisible) {
+		$panel.removeClass("visible");
+	} else {
+		$panel.addClass("visible");
+		// Load on first open; subsequent toggles reuse cached list
+		if (!jQuery("#git-log-list .git-log-commit").length) {
+			loadGitLog(0);
+		}
+	}
+}
+
+function loadGitLog(offset = 0) {
+	gitLogLoading = true;
+	const $list = jQuery("#git-log-list");
+	if (offset === 0) {
+		gitLogOffset = 0;
+		gitLogHasMore = true;
+		$list.html('<div class="git-log-loading">Loading...</div>');
+	} else {
+		$list.find(".git-log-loading-more").remove();
+		$list.append('<div class="git-log-loading git-log-loading-more">Loading more...</div>');
+	}
+	vscode.postMessage({ command: "loadGitLog", offset, limit: GIT_LOG_PAGE_SIZE });
+}
+
+function renderGitLog(commits, offset, hasMore) {
+	gitLogLoading = false;
+	gitLogHasMore = hasMore;
+	gitLogOffset = offset + commits.length;
+
+	const $list = jQuery("#git-log-list");
+	$list.find(".git-log-loading").remove();
+
+	if (offset === 0 && !commits.length) {
+		$list.html('<div class="git-log-empty">No commits found.</div>');
+		return;
+	}
+
+	commits.forEach(commit => {
+		const $item = jQuery('<div class="git-log-commit"></div>')
+			.data("hash", commit.hash);
+
+		if (commit.refs.length) {
+			const $refs = jQuery('<div class="git-log-refs"></div>');
+			commit.refs.forEach(ref => {
+				const $badge = jQuery('<span class="git-log-ref"></span>');
+				if (ref === "HEAD") {
+					$badge.addClass("git-log-ref-head").text("HEAD");
+				} else if (ref.startsWith("HEAD -> ")) {
+					$badge.addClass("git-log-ref-head").text(ref.slice(8));
+				} else if (ref.startsWith("tag: ")) {
+					$badge.addClass("git-log-ref-tag").text(ref.slice(5));
+				} else if (ref.includes("/")) {
+					$badge.addClass("git-log-ref-remote").text(ref);
+				} else {
+					$badge.addClass("git-log-ref-branch").text(ref);
+				}
+				$refs.append($badge);
+			});
+			$item.append($refs);
+		}
+
+		$item.append(
+			jQuery('<div class="git-log-subject"></div>')
+				.append(jQuery('<span class="git-log-hash"></span>').text(commit.shortHash + " "))
+				.append(document.createTextNode(commit.subject))
+		);
+
+		$item.append(
+			jQuery('<div class="git-log-meta"></div>').text(`${commit.author} · ${commit.relativeTime}`)
+		);
+
+		$list.append($item);
+	});
 }
 
 function addDataElement(elementProp, data) {

--- a/resources/js/diff-viewer-ui.js
+++ b/resources/js/diff-viewer-ui.js
@@ -43,6 +43,33 @@ function addButtonListeners() {
 	jQuery("#diff-mode-select").on("change", function () {
 		vscode.postMessage({ command: "switchDiffMode", viewMode: this.value });
 	});
+
+	jQuery("#file-filter-input")
+		.on("input", function () {
+			const val = this.value.trim();
+			applyFileFilter(val);
+			showFileFilterDropdown(val);
+		})
+		.on("focus", function () {
+			showFileFilterDropdown(this.value.trim());
+		})
+		.on("keydown", function (e) {
+			if (e.key === "Escape") {
+				jQuery("#file-filter-dropdown").hide();
+				this.blur();
+			}
+		})
+		.on("blur", function () {
+			// Delay lets a dropdown item click register before hiding
+			setTimeout(() => jQuery("#file-filter-dropdown").hide(), 150);
+		});
+
+	jQuery("#file-filter-dropdown").on("click", ".file-filter-option", function () {
+		const val = jQuery(this).data("value");
+		jQuery("#file-filter-input").val(val);
+		applyFileFilter(val);
+		jQuery("#file-filter-dropdown").hide();
+	});
 }
 
 function setShowCmd(showCmd) {
@@ -131,6 +158,7 @@ function showDiff2HtmlUi() {
 	}
 
 	addUiElementsToDiff2HtmlUi(config);
+	applyFileFilter(jQuery("#file-filter-input").val().trim());
 	jQuery(".custom-git-btn .btn-icon").toggle(config.showBtnIcon);
 	jQuery(".custom-git-btn .btn-long-desc").toggle(config.showBtnLongDesc);
 	jQuery(".custom-git-btn .btn-short-desc").toggle(config.showBtnShortDesc);
@@ -254,6 +282,50 @@ function addCustomGitBtn(options) {
 	jQuery(selector).append(
 		`<button class="custom-git-btn ${btnClass}" title="${title}" ${actionStr} ${relativeFilePathStr} ${fileChangeStateStr} ${hunkHeaderStr} ${isDisabledAfterClickedStr}><span class="btn-icon"><i class="${iconClass}"></i></span><span class="btn-short-desc">${shortDesc}</span><span class="btn-long-desc">${longDesc}</span></button>`
 	);
+}
+
+function applyFileFilter(filterText) {
+	const lower = filterText.toLowerCase();
+	jQuery(".d2h-file-wrapper").each(function () {
+		const fileName = jQuery(this).find(".d2h-file-name").text().toLowerCase();
+		jQuery(this).toggle(!lower || fileName.includes(lower));
+	});
+}
+
+function showFileFilterDropdown(filterText) {
+	const lower = filterText.toLowerCase();
+	const $dropdown = jQuery("#file-filter-dropdown");
+	$dropdown.empty();
+
+	const files = [];
+	jQuery(".d2h-file-wrapper").each(function () {
+		const name = jQuery(this).find(".d2h-file-name").first().text().trim();
+		if (name) files.push(name);
+	});
+
+	const matching = lower ? files.filter(f => f.toLowerCase().includes(lower)) : files;
+
+	if (!matching.length) {
+		$dropdown.hide();
+		return;
+	}
+
+	matching.forEach(file => {
+		const $item = jQuery('<div class="file-filter-option"></div>').data("value", file);
+		if (lower) {
+			// Highlight match using safe DOM methods (no HTML injection)
+			const idx = file.toLowerCase().indexOf(lower);
+			$item
+				.append(document.createTextNode(file.slice(0, idx)))
+				.append(jQuery('<mark></mark>').text(file.slice(idx, idx + lower.length)))
+				.append(document.createTextNode(file.slice(idx + lower.length)));
+		} else {
+			$item.text(file);
+		}
+		$dropdown.append($item);
+	});
+
+	$dropdown.show();
 }
 
 function addDataElement(elementProp, data) {

--- a/src/diff-viewer-view.ts
+++ b/src/diff-viewer-view.ts
@@ -177,16 +177,25 @@ function viewDiffDocument(document: vscode.TextDocument) {
 	doAction("showDiffContent", data);
 }
 
+function getTargetViewColumn(): vscode.ViewColumn {
+	const groups = vscode.window.tabGroups.all;
+	// Use the highest-numbered column (rightmost split) if more than one exists, otherwise create a new split
+	if (groups.length > 1) {
+		return Math.max(...groups.map(g => g.viewColumn)) as vscode.ViewColumn;
+	}
+	return vscode.ViewColumn.Beside;
+}
+
 function prepareViewerWebview() {
 	if (config.getAppConfig().componentsDisplayAtEditor?.includes(componentCode)) {
 		if (!webviewPanel) {
-			webviewPanel = vscode.window.createWebviewPanel("diffViewer", "Diff Viewer", { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true }, { enableScripts: true, enableFindWidget: true });
+			webviewPanel = vscode.window.createWebviewPanel("diffViewer", "Diff Viewer", { viewColumn: getTargetViewColumn(), preserveFocus: true }, { enableScripts: true, enableFindWidget: true });
 			webviewPanel.onDidDispose(() => {
 				webviewPanel = undefined;
 			});
 			prepareWebviewInner(webviewPanel.webview);
 		} else {
-			webviewPanel.reveal(vscode.ViewColumn.Beside, true);
+			webviewPanel.reveal(getTargetViewColumn(), true);
 		}
 	} else {
 		webviewPanel = undefined;

--- a/src/diff-viewer-view.ts
+++ b/src/diff-viewer-view.ts
@@ -242,20 +242,30 @@ function prepareWebviewInner(webview: vscode.Webview, overwriteHtml?: string) {
         </head>
         <body id="bdv-body">
             <div id="main-container">
-              <div id="diff2html-header">
-                <button id="refresh-btn">Refresh</button>
-                <select id="diff-mode-select" style="display:none"></select>
-                <button id="show-cmd-btn">Show CMD</button><button id="hide-cmd-btn">Hide CMD</button>
-                <span class="btn-group"><button id="zoom-in-btn"><i class="fa-solid fa-plus"></i></button>
-                <button id="zoom-out-btn"><i class="fa-solid fa-minus"></i></button></span>
-                <span id="file-filter-wrap">
-                  <input id="file-filter-input" type="text" placeholder="Filter files..." autocomplete="off" spellcheck="false" />
-                  <div id="file-filter-dropdown"></div>
-                </span>
+              <div id="git-log-panel">
+                <div id="git-log-panel-header">
+                  <span>Commits</span>
+                  <button id="git-log-refresh-btn" title="Refresh log"><i class="fa-solid fa-rotate"></i></button>
+                </div>
+                <div id="git-log-list"></div>
               </div>
-              <div id="diff2html-container"></div>
-              <div id="diff2html-footer">
-                <div id="cmd-viewer"><span id="cmd-content"></span></div>
+              <div id="diff-view-area">
+                <div id="diff2html-header">
+                  <button id="git-log-toggle-btn" title="Git Log"><i class="fa-solid fa-code-branch"></i></button>
+                  <button id="refresh-btn">Refresh</button>
+                  <select id="diff-mode-select" style="display:none"></select>
+                  <button id="show-cmd-btn">Show CMD</button><button id="hide-cmd-btn">Hide CMD</button>
+                  <span class="btn-group"><button id="zoom-in-btn"><i class="fa-solid fa-plus"></i></button>
+                  <button id="zoom-out-btn"><i class="fa-solid fa-minus"></i></button></span>
+                  <span id="file-filter-wrap">
+                    <input id="file-filter-input" type="text" placeholder="Filter files..." autocomplete="off" spellcheck="false" />
+                    <div id="file-filter-dropdown"></div>
+                  </span>
+                </div>
+                <div id="diff2html-container"></div>
+                <div id="diff2html-footer">
+                  <div id="cmd-viewer"><span id="cmd-content"></span></div>
+                </div>
               </div>
             </div>
         </body>
@@ -291,10 +301,18 @@ function handleMessageFromWebview(message: any) {
 		gitAdd(message.relativeFilePath, message.fileChangeState as Types.FileChangeState);
 	} else if (message.command === "gitUnstage") {
 		gitUnstage(message.relativeFilePath, message.fileChangeState as Types.FileChangeState);
+	} else if (message.command === "stageHunk") {
+		stageHunk(message.relativeFilePath, message.hunkHeader, message.fileChangeState as Types.FileChangeState);
+	} else if (message.command === "unstageHunk") {
+		unstageHunk(message.relativeFilePath, message.hunkHeader, message.fileChangeState as Types.FileChangeState);
 	} else if (message.command === "switchDiffMode") {
 		switchDiffMode(message.viewMode as "unstaged" | "staged");
 	} else if (message.command === "showLog") {
 		showLog(message.relativeFilePath);
+	} else if (message.command === "loadGitLog") {
+		sendGitLog(message.offset ?? 0, message.limit ?? GIT_LOG_PAGE_SIZE);
+	} else if (message.command === "viewCommitFromLog") {
+		viewCommitFromLog(message.hash);
 	}
 }
 
@@ -398,11 +416,24 @@ function getFileDiff(relativePath: string, fileChangeState: Types.FileChangeStat
 
 function revertHunk(relativePath: string, hunkHeader: string, fileChangeState: Types.FileChangeState, withWarning: boolean | undefined) {
 	const fileDiff: FileDiff | undefined = getFileDiff(relativePath, fileChangeState);
-	if (!fileDiff) {
-		return;
-	} else {
-		revertAction(fileDiff.getUsableHunkDiffByHunkHeader(hunkHeader), "hunk", withWarning, `Hunk Header: ${hunkHeader}`);
-	}
+	if (!fileDiff) { return; }
+	revertAction(fileDiff.getUsableHunkDiffByHunkHeader(hunkHeader), "hunk", withWarning, `Hunk Header: ${hunkHeader}`);
+}
+
+function stageHunk(relativePath: string, hunkHeader: string, fileChangeState: Types.FileChangeState) {
+	const fileDiff: FileDiff | undefined = getFileDiff(relativePath, fileChangeState);
+	if (!fileDiff) { return; }
+	const tmpPath = utils.createTempFile(`${uuidv4()}.diff`, fileDiff.getUsableHunkDiffByHunkHeader(hunkHeader));
+	utils.execShell(`git apply --cached -- ${tmpPath}`);
+	refresh(true);
+}
+
+function unstageHunk(relativePath: string, hunkHeader: string, fileChangeState: Types.FileChangeState) {
+	const fileDiff: FileDiff | undefined = getFileDiff(relativePath, fileChangeState);
+	if (!fileDiff) { return; }
+	const tmpPath = utils.createTempFile(`${uuidv4()}.diff`, fileDiff.getUsableHunkDiffByHunkHeader(hunkHeader));
+	utils.execShell(`git apply --cached -R -- ${tmpPath}`);
+	refresh(true);
 }
 
 function toggleFileDiff() {
@@ -435,6 +466,38 @@ async function showLog(relativePath: string) {
 
 	const hash = getCommitHash(selected);
 	updateDataByCmd(`git diff ${hash}~ ${hash} -- '${relativePath}'`);
+	data.viewMode = "commit";
+	doAction("showDiffContent", data);
+}
+
+const GIT_LOG_PAGE_SIZE = 20;
+
+function sendGitLog(offset: number, limit: number) {
+	try {
+		const raw = utils.execShell(utils.getGitLogCmd(offset, limit));
+		const commits: Types.GitCommit[] = raw.split("\n").filter(Boolean).map(line => {
+			const parts = line.split("\x01");
+			const refsStr = parts[6] ?? "";
+			const refs = refsStr ? refsStr.split(", ").map(r => r.trim()).filter(Boolean) : [];
+			return {
+				hash: parts[0] ?? "",
+				shortHash: parts[1] ?? "",
+				parentHashes: parts[2] ? parts[2].split(" ").filter(Boolean) : [],
+				subject: parts[3] ?? "",
+				author: parts[4] ?? "",
+				relativeTime: parts[5] ?? "",
+				refs,
+			};
+		});
+		doAction("showGitLog", { commits, offset, hasMore: commits.length === limit });
+	} catch {
+		doAction("showGitLog", { commits: [], offset, hasMore: false });
+	}
+}
+
+function viewCommitFromLog(hash: string) {
+	// git show works for all commits including root commits and merge commits
+	updateDataByCmd(`git show --format="" ${hash}`);
 	data.viewMode = "commit";
 	doAction("showDiffContent", data);
 }

--- a/src/diff-viewer-view.ts
+++ b/src/diff-viewer-view.ts
@@ -239,6 +239,10 @@ function prepareWebviewInner(webview: vscode.Webview, overwriteHtml?: string) {
                 <button id="show-cmd-btn">Show CMD</button><button id="hide-cmd-btn">Hide CMD</button>
                 <span class="btn-group"><button id="zoom-in-btn"><i class="fa-solid fa-plus"></i></button>
                 <button id="zoom-out-btn"><i class="fa-solid fa-minus"></i></button></span>
+                <span id="file-filter-wrap">
+                  <input id="file-filter-input" type="text" placeholder="Filter files..." autocomplete="off" spellcheck="false" />
+                  <div id="file-filter-dropdown"></div>
+                </span>
               </div>
               <div id="diff2html-container"></div>
               <div id="diff2html-footer">

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,13 @@ export type BetterDiffViewerOptions = {
 };
 
 export type FileChangeState = "ADDED" | "MOVED" | "CHANGED" | "DELETED" | "UNKNOWN";
+
+export type GitCommit = {
+	hash: string;
+	shortHash: string;
+	parentHashes: string[];
+	subject: string;
+	author: string;
+	relativeTime: string;
+	refs: string[];
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,6 +44,11 @@ export function viewStagedDiffForRepo(): string {
 	return `git diff --cached .`;
 }
 
+// %x01 as field separator -- safe since git disallows control chars in commit messages
+export function getGitLogCmd(offset: number, limit: number): string {
+	return `git --no-pager log --all --topo-order --skip=${offset} --max-count=${limit} --pretty=format:'%H%x01%h%x01%P%x01%s%x01%an%x01%ar%x01%D'`;
+}
+
 export function execShell(cmd: string): string {
 	const preCmd = `cd '${repo}';`;
 	try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,15 @@ export let extensionPath: string;
 
 const tempFolderName = "temp";
 const repo: string = getRepoPath();
+const gitRoot: string = resolveGitRoot(repo);
+
+function resolveGitRoot(fromPath: string): string {
+	try {
+		return cp.execSync('git rev-parse --show-toplevel', { cwd: fromPath, encoding: 'utf8' }).trim();
+	} catch {
+		return fromPath;
+	}
+}
 
 export function viewDiffInFile(fromHash: string, toHash: string, oldFilePath: string, newFilePath: string): string {
 	if (fromHash === UNCOMMITTED) {
@@ -60,7 +69,7 @@ export function throwError(message: string): never {
 }
 
 export function getAbsolutePath(relativePath: string) {
-	return path.join(getRepoPath(), relativePath);
+	return path.join(gitRoot, relativePath);
 }
 
 export function createTempFile(filename: string, fileContent: string) {


### PR DESCRIPTION
## Summary

- **Git log tree panel** -- toggle with the branch icon in the toolbar to browse all-branch commit history; click any commit to view its diff
- **Lazy-load commits** -- loads 20 at a time and fetches the next page as the user scrolls, so large repos open instantly
- **Hunk-level stage / unstage** -- Add and Remove buttons appear inline before the `@@` marker on each hunk (alongside the existing Revert button)
- **Hunk button positioning fix** -- Revert was floating in the wrong position due to a flex layout shift; now renders inline before `@@`
- **File filter** -- filter files in the diff view by name with an autocomplete dropdown
- **Smart tab placement** -- opens in the rightmost split when multiple editor groups exist, otherwise opens beside
- **Version bump** -- 1.1.0 → 1.1.1

## Test plan

- [ ] Open diff viewer and click the branch icon -- Commits panel should appear on the left
- [ ] Click a commit -- diff should load on the right
- [ ] Scroll to the bottom of the commit list -- next 20 commits should load automatically
- [ ] Click refresh icon in the Commits panel header -- list should reload from the top
- [ ] In unstaged view, check each hunk header shows Revert + Add buttons inline before `@@`
- [ ] Click Add on a hunk -- hunk should be staged; diff refreshes
- [ ] Switch to staged view -- each hunk header should show Remove; click it to unstage
- [ ] Toggle the log panel closed and reopen -- cached list reused (no extra network call)
- [ ] Verify dark mode styling for the log panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)